### PR TITLE
Add QuestRate Stat + PetHPPercent Fix

### DIFF
--- a/Client/Scenes/GameScene.cs
+++ b/Client/Scenes/GameScene.cs
@@ -2314,6 +2314,7 @@ namespace Client.Scenes
                     case Stat.DropRate:
                     case Stat.ExperienceRate:
                     case Stat.SkillRate:
+                    case Stat.QuestRate:
                     case Stat.GoldRate:
                         label.ForeColour = Color.Yellow;
 
@@ -2471,6 +2472,7 @@ namespace Client.Scenes
                     case Stat.DropRate:
                     case Stat.ExperienceRate:
                     case Stat.SkillRate:
+                    case Stat.QuestRate:
                     case Stat.GoldRate:
                         label.ForeColour = Color.Yellow;
                         break;

--- a/Library/Stat.cs
+++ b/Library/Stat.cs
@@ -649,9 +649,6 @@ namespace Library
         [StatDescription(Title = "Pet's DC", Format = "{0:+#0%;-#0%;#0%}", Mode = StatType.Percent)]
         PetDCPercent,
 
-        [StatDescription(Title = "Pet's Health", Format = "{0:+#0%;-#0%;#0%}", Mode = StatType.Percent)]
-        PetHPPercent,
-
         [StatDescription(Title = "Locates Boss Monsters on the Map", Mode = StatType.Text)]
         BossTracker,
         [StatDescription(Title = "Locates Players on the Map", Mode = StatType.Text)]
@@ -797,6 +794,12 @@ namespace Library
 
         [StatDescription(Title = "Superior Magic Shield", Format = "{0:+#0;-#0;#0}", Mode = StatType.Default)]
         SuperiorMagicShield,
+
+        [StatDescription(Title = "Pet's Health", Format = "{0:+#0%;-#0%;#0%}", Mode = StatType.Percent)]
+        PetHPPercent,
+
+        [StatDescription(Title = "Quest Rate", Format = "x{0}", Mode = StatType.Default)]
+        QuestRate,
     }
 
     public enum StatSource

--- a/Server/Models/MonsterObject.cs
+++ b/Server/Models/MonsterObject.cs
@@ -3028,6 +3028,9 @@ namespace Server.Models
                     switch (task.Task)
                     {
                         case QuestTaskType.KillMonster:
+                            if (owner.Stats[Stat.QuestRate] > 1)
+                                count *= owner.Stats[Stat.QuestRate] - 1;
+
                             userTask.Amount = Math.Min(task.Amount, userTask.Amount + count);
                             changed = true;
                             break;

--- a/Server/Models/PlayerObject.cs
+++ b/Server/Models/PlayerObject.cs
@@ -3019,6 +3019,7 @@ namespace Server.Models
 
             Stats[Stat.PickUpRadius] = 1;
             Stats[Stat.SkillRate] = 1;
+            Stats[Stat.QuestRate] = 1;
             Stats[Stat.CriticalChance] = 1;
 
             Stats.Add(Character.HermitStats);

--- a/Server/Views/ItemInfoView.cs
+++ b/Server/Views/ItemInfoView.cs
@@ -106,6 +106,7 @@ namespace Server.Views
             builder.Append((info == null ? "Drop Rate" : string.Format("+{0}", info.Stats[Stat.DropRate])) + ", ");
             builder.Append((info == null ? "Gold Rate" : string.Format("+{0}", info.Stats[Stat.GoldRate])) + ", ");
             builder.Append((info == null ? "Skill Rate" : string.Format("+{0}", info.Stats[Stat.SkillRate])) + ", ");
+            builder.Append((info == null ? "Quest Rate" : string.Format("+{0}", info.Stats[Stat.QuestRate])) + ", ");
             builder.Append((info == null ? "Duration" : string.Format("+{0}", info.Stats[Stat.Duration])) + ", ");
             builder.Append((info == null ? "Inventory Weight" : string.Format("+{0}", info.Stats[Stat.BagWeight])) + ", ");
             builder.Append((info == null ? "Wear Weight" : string.Format("+{0}", info.Stats[Stat.WearWeight])) + ", ");


### PR DESCRIPTION
Added QuestRate Stat, multiplies amount of killed monsters towards KillMonster Task.
Fixed location of PetHPPercent, didn't realise that adding midway would throw off existing Items in DB.